### PR TITLE
chore(ci): dynamically set go test coverageprofile based on module name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,5 @@ jobs:
       - name: upload-coverage-to-codecov
         uses: codecov/codecov-action@v5
         with:
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,14 @@ endef
 test:
 ifdef module
 	@echo "Running tests for module: $(module)"
-	go test -v -race -cover -coverprofile=coverage.out -covermode=atomic -short=$(short) ./$(module)/...
+	@coverprofile_base_name=$(subst /,-,$(module))-coverage.out; \
+	go test -v -race -cover -coverprofile=$$coverprofile_base_name -covermode=atomic -short=$(short) ./$(module)/...
 else
 	@echo "Running tests for all modules"
 	@for mod in $(modules); do \
 		echo "Testing $$mod..."; \
-		go test -v -race -cover -coverprofile=coverage.out -covermode=atomic -short=$(short) ./$$mod/... || exit 1; \
+		coverprofile_base_name=$$(echo $$mod | tr '/' '-')-coverage.out; \
+		go test -v -race -cover -coverprofile=$$coverprofile_base_name -covermode=atomic -short=$(short) ./$$mod/... || exit 1; \
 	done
 endif
 


### PR DESCRIPTION
### Description

dynamically set go test coverageprofile based on module name. this allows codecov to work on multiple modules
