### PR TITLE
perf(gameplay): optimize round/game ended ws payloads

### DIFF
--- a/services/gameplay/internal/gameevents/game.go
+++ b/services/gameplay/internal/gameevents/game.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	TypeGameEnded = "game_ended"
+	TypeGameEnded         = "game_ended"
+	TypePlayerFinalResult = "player_final_result"
 )
 
 type PlayerFinalResult struct {

--- a/services/gameplay/internal/gameevents/round.go
+++ b/services/gameplay/internal/gameevents/round.go
@@ -24,6 +24,7 @@ const (
 	TypeUpdateDrawing      = "update_drawing"
 	TypeEndDrawing         = "end_drawing"
 	TypeRoundEnded         = "round_ended"
+	TypePlayerRoundResult  = "player_round_result"
 )
 
 type ArtistSelectedPayload struct {

--- a/services/gameplay/internal/gameflow/internal/activities/publish_game_event.go
+++ b/services/gameplay/internal/gameflow/internal/activities/publish_game_event.go
@@ -9,79 +9,27 @@ import (
 	"github.com/spazzle-io/spazzle-api/services/gameplay/internal/eventbus"
 )
 
-// TODO: Rewrite this activity to accept a list of game event entries for cases where we want
-// to send messages of the same type to all/multiple players e.g game/round ended where
-// we want to send each player their result rather than broadcasting all results to everyone.
-//
-// Proposed input structure:
-//	type PublishGameEventsParams struct {
-//	   GameServerID uuid.UUID
-//	   GameID       uuid.UUID
-//	   StreamType   eventbus.StreamType
-//	   EventType    string
-//	   Events       []GameEventEntry
-//	}
-//
-//	type GameEventEntry struct {
-//	   TargetClientID uuid.UUID
-//	   CorrelationID  uuid.UUID
-//	   EventPayload   any
-//	   Marker         eventbus.Marker
-//	}
-//
-// Proposed output structure:
-//	type PublishGameEventResult struct {
-//		MessageID string
-//	}
-// The workflow already has correlation IDs for each message and doesnt need to reference bus message IDs
-// so it can be safely dropped from the output.
-//
-// When sending batch messages, we also want to use different activity options configs that are
-// better suited for a long running activity with limited number of retries e.g
-//	bulkAO := workflow.ActivityOptions{
-//		StartToCloseTimeout: 5 * time.Minute,
-//		HeartbeatTimeout:    30 * time.Second,
-//		RetryPolicy: &temporal.RetryPolicy{
-//			InitialInterval:    2 * time.Second,
-//			MaximumInterval:    30 * time.Second,
-//			BackoffCoefficient: 2,
-//			MaximumAttempts:    3,
-//		},
-//	}
-//
-
-type PublishGameEventParams struct {
-	GameServerID   uuid.UUID
-	GameID         uuid.UUID
-	StreamType     eventbus.StreamType
+type GameEventEntry struct {
 	TargetClientID uuid.UUID
 	CorrelationID  uuid.UUID
-	EventType      string
 	EventPayload   any
 	Marker         eventbus.Marker
 }
 
-type PublishGameEventResult struct {
-	MessageID string
+type PublishGameEventsParams struct {
+	GameServerID uuid.UUID
+	GameID       uuid.UUID
+	StreamType   eventbus.StreamType
+	EventType    string
+	Events       []GameEventEntry
 }
 
-func (a *Activities) PublishGameEvent(
+type PublishGameEventsResult struct{}
+
+func (a *Activities) PublishGameEvents(
 	ctx context.Context,
-	params PublishGameEventParams,
-) (*PublishGameEventResult, error) {
-	payload, err := json.Marshal(params.EventPayload)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal game event payload: %w of type: %s", err, params.EventType)
-	}
-
-	eventMsg := eventbus.PublishMessage{
-		Type:           params.EventType,
-		Payload:        payload,
-		TargetClientID: params.TargetClientID,
-		CorrelationID:  params.CorrelationID,
-		Marker:         params.Marker,
-	}
-
+	params PublishGameEventsParams,
+) (*PublishGameEventsResult, error) {
 	game := eventbus.GameIdentifier{
 		GameID:       params.GameID,
 		GameServerID: params.GameServerID,
@@ -92,9 +40,25 @@ func (a *Activities) PublishGameEvent(
 		return nil, err
 	}
 
-	messageID, err := session.Publish(ctx, params.StreamType, eventMsg)
+	for _, event := range params.Events {
+		payload, err := json.Marshal(event.EventPayload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal game event payload of type: %s: %w", params.EventType, err)
+		}
 
-	return &PublishGameEventResult{
-		MessageID: messageID,
-	}, err
+		eventMsg := eventbus.PublishMessage{
+			Type:           params.EventType,
+			Payload:        payload,
+			TargetClientID: event.TargetClientID,
+			CorrelationID:  event.CorrelationID,
+			Marker:         event.Marker,
+		}
+
+		_, err = session.Publish(ctx, params.StreamType, eventMsg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to publish event: %w", err)
+		}
+	}
+
+	return &PublishGameEventsResult{}, err
 }

--- a/services/gameplay/internal/gameflow/internal/activities/publish_game_event_test.go
+++ b/services/gameplay/internal/gameflow/internal/activities/publish_game_event_test.go
@@ -16,30 +16,34 @@ import (
 func TestPublishGameEvent(t *testing.T) {
 	deps := setupActivities(t)
 
-	params := PublishGameEventParams{
-		GameServerID:   uuid.New(),
-		GameID:         uuid.New(),
-		StreamType:     eventbus.GameEventsStreamType,
-		TargetClientID: uuid.New(),
-		CorrelationID:  uuid.New(),
-		EventType:      gameevents.TypeBeginDrawing,
-		EventPayload: &gameevents.BeginDrawingPayload{
-			CurrentRound: uint8(1),
-			EndsAt:       time.Now().UTC(),
+	params := PublishGameEventsParams{
+		GameServerID: uuid.New(),
+		GameID:       uuid.New(),
+		StreamType:   eventbus.GameEventsStreamType,
+		EventType:    gameevents.TypeBeginDrawing,
+		Events: []GameEventEntry{
+			{
+				TargetClientID: uuid.New(),
+				CorrelationID:  uuid.New(),
+				EventPayload: &gameevents.BeginDrawingPayload{
+					CurrentRound: uint8(1),
+					EndsAt:       time.Now().UTC(),
+				},
+				Marker: eventbus.MarkerRoundEnded,
+			},
 		},
-		Marker: eventbus.MarkerRoundEnded,
 	}
 
-	marshaledPayload, err := json.Marshal(params.EventPayload)
+	marshaledPayload, err := json.Marshal(params.Events[0].EventPayload)
 	require.NoError(t, err)
 	require.NotEmpty(t, marshaledPayload)
 
 	eventMsg := eventbus.PublishMessage{
 		Type:           params.EventType,
 		Payload:        marshaledPayload,
-		TargetClientID: params.TargetClientID,
-		CorrelationID:  params.CorrelationID,
-		Marker:         params.Marker,
+		TargetClientID: params.Events[0].TargetClientID,
+		CorrelationID:  params.Events[0].CorrelationID,
+		Marker:         params.Events[0].Marker,
 	}
 
 	game := eventbus.GameIdentifier{
@@ -57,11 +61,9 @@ func TestPublishGameEvent(t *testing.T) {
 		Times(1).
 		Return("msg-id", nil)
 
-	expectedResult := &PublishGameEventResult{
-		MessageID: "msg-id",
-	}
+	expectedResult := &PublishGameEventsResult{}
 
-	result, err := deps.Activities.PublishGameEvent(context.Background(), params)
+	result, err := deps.Activities.PublishGameEvents(context.Background(), params)
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 }

--- a/services/gameplay/internal/gameflow/internal/workflow/event.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/event.go
@@ -14,11 +14,146 @@ import (
 
 const EventDeliveryTimeout = time.Second * 5
 
-type sendGameEventOpts struct {
-	StreamType     eventbus.StreamType
-	TargetClientID uuid.UUID
-	WaitForAck     bool
-	Marker         eventbus.Marker
+type sendGameEventConfig struct {
+	streamType     eventbus.StreamType
+	targetClientID uuid.UUID
+	waitForAck     bool
+	marker         eventbus.Marker
+}
+
+type SendGameEventOption func(*sendGameEventConfig)
+
+func WithTargetClient(id uuid.UUID) SendGameEventOption {
+	return func(c *sendGameEventConfig) {
+		c.targetClientID = id
+	}
+}
+
+func WithAck() SendGameEventOption {
+	return func(c *sendGameEventConfig) {
+		c.waitForAck = true
+	}
+}
+
+func WithStreamType(st eventbus.StreamType) SendGameEventOption {
+	return func(c *sendGameEventConfig) {
+		c.streamType = st
+	}
+}
+
+func WithMarker(m eventbus.Marker) SendGameEventOption {
+	return func(c *sendGameEventConfig) {
+		c.marker = m
+	}
+}
+
+func newSendGameEventConfig(opts []SendGameEventOption) sendGameEventConfig {
+	cfg := sendGameEventConfig{
+		streamType: eventbus.GameEventsStreamType,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	return cfg
+}
+
+func sendGameEvent[T any](
+	ctx workflow.Context,
+	state *GameState,
+	notifyCh workflow.Channel,
+	eventType string,
+	payload T,
+	opts ...SendGameEventOption,
+) (eventDelivered bool, err error) {
+	cfg := newSendGameEventConfig(opts)
+
+	correlationID, err := generateUUID(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to generate correlation ID: %w", err)
+	}
+
+	if cfg.waitForAck {
+		state.PendingAcks[correlationID] = &PendingAck{
+			CorrelationID: correlationID,
+			ReceivedFrom:  make(map[uuid.UUID]gameevents.AckStatus),
+			CreatedAt:     workflow.Now(ctx).UTC(),
+		}
+		defer delete(state.PendingAcks, correlationID)
+	}
+
+	var a *activities.Activities
+	var publishGameEventResult activities.PublishGameEventsResult
+
+	publishGameEventsParams := activities.PublishGameEventsParams{
+		GameServerID: getGameServerID(ctx),
+		GameID:       state.GameID,
+		StreamType:   cfg.streamType,
+		EventType:    eventType,
+		Events: []activities.GameEventEntry{
+			{
+				TargetClientID: cfg.targetClientID,
+				CorrelationID:  correlationID,
+				EventPayload:   payload,
+				Marker:         cfg.marker,
+			},
+		},
+	}
+
+	err = workflow.ExecuteActivity(ctx, a.PublishGameEvents, publishGameEventsParams).Get(ctx, &publishGameEventResult)
+	if err != nil {
+		return false, fmt.Errorf("failed to publish game event: %w", err)
+	}
+
+	if cfg.waitForAck {
+		return waitForEventAck(ctx, state, correlationID, EventDeliveryTimeout, notifyCh)
+	}
+
+	return false, nil
+}
+
+func SendGameEvents[T any](
+	ctx workflow.Context,
+	state *GameState,
+	eventType string,
+	payload T,
+	targets []uuid.UUID,
+	opts ...SendGameEventOption,
+) error {
+	cfg := newSendGameEventConfig(opts)
+
+	events := make([]activities.GameEventEntry, len(targets))
+	for i, clientID := range targets {
+		correlationID, err := generateUUID(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to generate correlation ID: %w", err)
+		}
+
+		events[i] = activities.GameEventEntry{
+			TargetClientID: clientID,
+			CorrelationID:  correlationID,
+			EventPayload:   payload,
+			Marker:         cfg.marker,
+		}
+	}
+
+	var a *activities.Activities
+	var publishGameEventResult activities.PublishGameEventsResult
+
+	publishGameEventsParams := activities.PublishGameEventsParams{
+		GameServerID: getGameServerID(ctx),
+		GameID:       state.GameID,
+		StreamType:   cfg.streamType,
+		EventType:    eventType,
+		Events:       events,
+	}
+
+	err := workflow.ExecuteActivity(ctx, a.PublishGameEvents, publishGameEventsParams).Get(ctx, &publishGameEventResult)
+	if err != nil {
+		return fmt.Errorf("failed to publish game events: %w", err)
+	}
+
+	return nil
 }
 
 func waitForEventAck(
@@ -28,7 +163,7 @@ func waitForEventAck(
 	deliveryTimeout time.Duration,
 	notifyCh workflow.Channel,
 ) (eventDelivered bool, err error) {
-	pendingAcks := state.PendingAcks[correlationID]
+	pendingAck := state.PendingAcks[correlationID]
 	numGameServerInstances := len(state.GameServerInstances)
 
 	if numGameServerInstances == 0 {
@@ -42,19 +177,16 @@ func waitForEventAck(
 	timedOut := false
 
 	for {
-		for _, instanceID := range sortedUUIDs(pendingAcks.ReceivedFrom) {
-			ackStatus := pendingAcks.ReceivedFrom[instanceID]
-
-			if ackStatus == gameevents.AckStatusDelivered {
+		for _, instanceID := range sortedUUIDs(pendingAck.ReceivedFrom) {
+			switch pendingAck.ReceivedFrom[instanceID] {
+			case gameevents.AckStatusDelivered:
 				return true, nil
-			}
-
-			if ackStatus == gameevents.AckStatusFailed {
+			case gameevents.AckStatusFailed:
 				return false, errors.New("event not delivered successfully")
 			}
 		}
 
-		if len(pendingAcks.ReceivedFrom) >= numGameServerInstances {
+		if len(pendingAck.ReceivedFrom) >= numGameServerInstances {
 			return false, nil
 		}
 
@@ -75,64 +207,4 @@ func waitForEventAck(
 
 		selector.Select(ctx)
 	}
-}
-
-func sendGameEvent[T any](
-	ctx workflow.Context,
-	state *GameState,
-	notifyCh workflow.Channel,
-	eventType string,
-	payload T,
-	opts *sendGameEventOpts,
-) (eventDelivered bool, err error) {
-	o := sendGameEventOpts{
-		StreamType: eventbus.GameEventsStreamType,
-	}
-	if opts != nil {
-		if opts.StreamType != "" {
-			o.StreamType = opts.StreamType
-		}
-		o.TargetClientID = opts.TargetClientID
-		o.WaitForAck = opts.WaitForAck
-		o.Marker = opts.Marker
-	}
-
-	correlationID, err := generateUUID(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to generate correlation ID: %w", err)
-	}
-
-	if o.WaitForAck {
-		state.PendingAcks[correlationID] = &PendingAck{
-			CorrelationID: correlationID,
-			ReceivedFrom:  make(map[uuid.UUID]gameevents.AckStatus),
-			CreatedAt:     workflow.Now(ctx).UTC(),
-		}
-		defer delete(state.PendingAcks, correlationID)
-	}
-
-	var a *activities.Activities
-
-	publishGameEventParams := activities.PublishGameEventParams{
-		GameServerID:   getGameServerID(ctx),
-		GameID:         state.GameID,
-		StreamType:     o.StreamType,
-		TargetClientID: o.TargetClientID,
-		CorrelationID:  correlationID,
-		EventType:      eventType,
-		EventPayload:   payload,
-		Marker:         o.Marker,
-	}
-	var publishGameEventResult activities.PublishGameEventResult
-
-	err = workflow.ExecuteActivity(ctx, a.PublishGameEvent, publishGameEventParams).Get(ctx, &publishGameEventResult)
-	if err != nil {
-		return false, fmt.Errorf("failed to execute publish game event activity: %w", err)
-	}
-
-	if o.WaitForAck {
-		return waitForEventAck(ctx, state, correlationID, EventDeliveryTimeout, notifyCh)
-	}
-
-	return false, nil
 }

--- a/services/gameplay/internal/gameflow/internal/workflow/event.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/event.go
@@ -21,6 +21,11 @@ type sendGameEventConfig struct {
 	marker         eventbus.Marker
 }
 
+type GameEvent[T any] struct {
+	TargetClientID uuid.UUID
+	Payload        T
+}
+
 type SendGameEventOption func(*sendGameEventConfig)
 
 func WithTargetClient(id uuid.UUID) SendGameEventOption {
@@ -112,27 +117,26 @@ func sendGameEvent[T any](
 	return false, nil
 }
 
-func SendGameEvents[T any](
+func sendGameEvents[T any](
 	ctx workflow.Context,
 	state *GameState,
 	eventType string,
-	payload T,
-	targets []uuid.UUID,
+	events []GameEvent[T],
 	opts ...SendGameEventOption,
 ) error {
 	cfg := newSendGameEventConfig(opts)
 
-	events := make([]activities.GameEventEntry, len(targets))
-	for i, clientID := range targets {
+	entries := make([]activities.GameEventEntry, len(events))
+	for i, event := range events {
 		correlationID, err := generateUUID(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to generate correlation ID: %w", err)
 		}
 
-		events[i] = activities.GameEventEntry{
-			TargetClientID: clientID,
+		entries[i] = activities.GameEventEntry{
+			TargetClientID: event.TargetClientID,
 			CorrelationID:  correlationID,
-			EventPayload:   payload,
+			EventPayload:   event.Payload,
 			Marker:         cfg.marker,
 		}
 	}
@@ -145,7 +149,7 @@ func SendGameEvents[T any](
 		GameID:       state.GameID,
 		StreamType:   cfg.streamType,
 		EventType:    eventType,
-		Events:       events,
+		Events:       entries,
 	}
 
 	err := workflow.ExecuteActivity(ctx, a.PublishGameEvents, publishGameEventsParams).Get(ctx, &publishGameEventResult)

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_global_signals.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_global_signals.go
@@ -102,7 +102,7 @@ func handlePlayersJoinedSignal(ctx workflow.Context, state *GameState, notifyCh 
 
 			notifyCh.Send(ctx, struct{}{})
 
-			_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypePlayersJoined, payload, nil)
+			_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypePlayersJoined, payload)
 			if err != nil {
 				state.Logger().Error("failed to send players joined event", "error", err)
 			}
@@ -144,7 +144,7 @@ func handlePlayersLeftSignal(ctx workflow.Context, state *GameState, notifyCh wo
 
 			notifyCh.Send(ctx, struct{}{})
 
-			_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypePlayersLeft, payload, nil)
+			_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypePlayersLeft, payload)
 			if err != nil {
 				state.Logger().Error("failed to send players left event", "error", err)
 			}
@@ -190,7 +190,7 @@ func handleClearPlayerReports(ctx workflow.Context, state *GameState, notifyCh w
 		payload := gameevents.PlayerReportsClearedPayload{
 			PlayerIDs: sig.PlayerIDs,
 		}
-		_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypePlayerReportsCleared, payload, nil)
+		_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypePlayerReportsCleared, payload)
 		if err != nil {
 			state.Logger().Error("failed to send player reports cleared event", "error", err)
 			return
@@ -245,7 +245,7 @@ func handlePlayerEjections(ctx workflow.Context, state *GameState, notifyCh work
 			CurrentRound: state.CurrentRound,
 			Ejections:    ejections,
 		}
-		_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypePlayersEjected, payload, nil)
+		_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypePlayersEjected, payload)
 		if err != nil {
 			state.Logger().Error("failed to send players ejected event", "error", err)
 			return
@@ -456,7 +456,7 @@ func processPlayerReports(
 		CurrentRound: state.CurrentRound,
 		Reports:      reports,
 	}
-	_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypePlayersReported, payload, nil)
+	_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypePlayersReported, payload)
 	if err != nil {
 		state.Logger().Error("failed to send players reported event", "error", err)
 	}

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_game.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_game.go
@@ -35,17 +35,22 @@ func endGame(ctx workflow.Context, state *GameState, notifyCh workflow.Channel) 
 
 	state.EndedAt = workflow.Now(ctx).UTC()
 
-	// TODO: gameResult should only broadcast the top 10 players and not all players as this will scale linearly with
-	// number of players and exceed our 4KB write limit on wss connections.
-	// Proposed impl: gameResult.Results to be set to results[:min(10, len(results))]
-
-	// TODO: given the change to only broadcast the top 10 players, use the new publish game event activity to send
-	// an end game message to each player in one batch.
+	events := make([]GameEvent[*gameevents.PlayerFinalResult], len(results))
+	for i, r := range results {
+		events[i] = GameEvent[*gameevents.PlayerFinalResult]{
+			TargetClientID: r.PlayerID,
+			Payload:        r,
+		}
+	}
+	err = sendGameEvents(ctx, state, gameevents.TypePlayerFinalResult, events)
+	if err != nil {
+		return fmt.Errorf("failed to send final player results: %w", err)
+	}
 
 	gameResult := gameevents.GameEndedPayload{
 		TotalRounds: state.CurrentRound,
 		TotalPot:    state.GamePot,
-		Results:     results,
+		Results:     results[:min(10, len(results))],
 	}
 	_, err = sendGameEvent(ctx, state, notifyCh, gameevents.TypeGameEnded, gameResult)
 	if err != nil {

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_game.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_game.go
@@ -47,7 +47,7 @@ func endGame(ctx workflow.Context, state *GameState, notifyCh workflow.Channel) 
 		TotalPot:    state.GamePot,
 		Results:     results,
 	}
-	_, err = sendGameEvent(ctx, state, notifyCh, gameevents.TypeGameEnded, gameResult, nil)
+	_, err = sendGameEvent(ctx, state, notifyCh, gameevents.TypeGameEnded, gameResult)
 	if err != nil {
 		return fmt.Errorf("failed to send game ended event: %w", err)
 	}

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_game_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_game_test.go
@@ -61,15 +61,27 @@ func (s *EndGameTestSuite) TestEndGame() {
 		})
 	}, 200*time.Millisecond)
 
+	numPlayerFinalResultsSent := 0
 	sentGameEndedEvent := false
+
 	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			for _, event := range params.Events {
-				if params.EventType == gameevents.TypeGameEnded {
-					sentGameEndedEvent = true
+			switch params.EventType {
+			case gameevents.TypePlayerFinalResult:
+				for _, event := range params.Events {
+					var payload gameevents.PlayerFinalResult
+					raw := event.EventPayload.(map[string]interface{})
+					b, err := json.Marshal(raw)
+					s.Require().NoError(err)
+					s.Require().NoError(json.Unmarshal(b, &payload))
+					numPlayerFinalResultsSent++
+				}
 
+			case gameevents.TypeGameEnded:
+				sentGameEndedEvent = true
+				for _, event := range params.Events {
 					var payload gameevents.GameEndedPayload
 					raw := event.EventPayload.(map[string]interface{})
 					b, err := json.Marshal(raw)
@@ -82,15 +94,18 @@ func (s *EndGameTestSuite) TestEndGame() {
 					s.Len(payload.Results, 2)
 				}
 
-				if event.TargetClientID == uuid.Nil {
-					return
-				}
+			default:
+				for _, event := range params.Events {
+					if event.TargetClientID == uuid.Nil {
+						continue
+					}
 
-				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-					CorrelationID: event.CorrelationID,
-					InstanceID:    instanceID,
-					Status:        gameevents.AckStatusDelivered,
-				})
+					s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+						CorrelationID: event.CorrelationID,
+						InstanceID:    instanceID,
+						Status:        gameevents.AckStatusDelivered,
+					})
+				}
 			}
 		}).
 		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
@@ -121,6 +136,7 @@ func (s *EndGameTestSuite) TestEndGame() {
 	s.env.ExecuteWorkflow(GameWorkflow, input)
 
 	s.True(sentGameEndedEvent)
+	s.Equal(2, numPlayerFinalResultsSent)
 	s.True(executedArchiveGameActivity)
 	s.Equal(gameID, capturedState.GameID)
 	s.Equal(types.PhaseEndGame, capturedState.Phase)

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_game_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_game_test.go
@@ -62,36 +62,38 @@ func (s *EndGameTestSuite) TestEndGame() {
 	}, 200*time.Millisecond)
 
 	sentGameEndedEvent := false
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeGameEnded {
-				sentGameEndedEvent = true
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeGameEnded {
+					sentGameEndedEvent = true
 
-				var payload gameevents.GameEndedPayload
-				raw := params.EventPayload.(map[string]interface{})
-				b, err := json.Marshal(raw)
-				s.Require().NoError(err)
-				s.Require().NoError(json.Unmarshal(b, &payload))
+					var payload gameevents.GameEndedPayload
+					raw := event.EventPayload.(map[string]interface{})
+					b, err := json.Marshal(raw)
+					s.Require().NoError(err)
+					s.Require().NoError(json.Unmarshal(b, &payload))
 
-				s.Equal(uint8(10), payload.TotalRounds)
-				s.Equal("2000000000000000000", payload.TotalPot)
-				s.NotEmpty(payload.Results)
-				s.Len(payload.Results, 2)
+					s.Equal(uint8(10), payload.TotalRounds)
+					s.Equal("2000000000000000000", payload.TotalPot)
+					s.NotEmpty(payload.Results)
+					s.Len(payload.Results, 2)
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
+				})
 			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeGameEnded {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -101,9 +103,7 @@ func (s *EndGameTestSuite) TestEndGame() {
 				capturedState = &state
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	executedArchiveGameActivity := false

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_game_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_game_test.go
@@ -39,8 +39,6 @@ func (s *EndGameTestSuite) TestEndGame() {
 	player1 := uuid.New()
 	player2 := uuid.New()
 
-	var capturedState *types.GameStateView
-
 	input := types.GameInput{
 		GameID:          gameID,
 		NumRounds:       10,
@@ -109,15 +107,6 @@ func (s *EndGameTestSuite) TestEndGame() {
 			}
 		}).
 		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
-			if params.EventType == gameevents.TypeGameEnded {
-				val, err := s.env.QueryWorkflow(QueryGetGameState)
-				s.NoError(err)
-
-				var state types.GameStateView
-				s.NoError(val.Get(&state))
-				capturedState = &state
-			}
-
 			return &activities.PublishGameEventsResult{}, nil
 		})
 
@@ -134,6 +123,11 @@ func (s *EndGameTestSuite) TestEndGame() {
 		ID: serverID.String(),
 	})
 	s.env.ExecuteWorkflow(GameWorkflow, input)
+
+	val, err := s.env.QueryWorkflow(QueryGetGameState)
+	s.NoError(err)
+	var capturedState types.GameStateView
+	s.NoError(val.Get(&capturedState))
 
 	s.True(sentGameEndedEvent)
 	s.Equal(2, numPlayerFinalResultsSent)

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_round.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_round.go
@@ -83,27 +83,31 @@ func endRound(ctx workflow.Context, state *GameState, notifyCh workflow.Channel)
 		return fmt.Errorf("could not calculate provisional payouts: %v", err)
 	}
 
+	events := make([]GameEvent[*gameevents.PlayerRoundResult], len(results))
+	for i, r := range results {
+		events[i] = GameEvent[*gameevents.PlayerRoundResult]{
+			TargetClientID: r.PlayerID,
+			Payload:        r,
+		}
+	}
+	err = sendGameEvents(ctx, state, gameevents.TypePlayerRoundResult, events)
+	if err != nil {
+		return fmt.Errorf("failed to send player round results: %w", err)
+	}
+
 	isFinalRound := int32(state.CurrentRound) >= state.NumRounds
+	broadcastedResults := topRoundResults(correctGuessersResults, artistResult, 10)
 
-	// TODO: roundResult should only send top 10 guessers for the round + artist in the roundResult.Results list.
-	// This is to prevent this payload from ballooning as it will scale linearly with number of players
-	// and we only have 4KB write limit to player wss connections.
-	// Proposed impl: implement an extractTopResults helper func that takes in correctGuessersResults(already sorted),
-	// artistResult, and n=10. Then return first n from correctGuessersResults and append artist at the end.
-
-	// TODO: With the change to only send top n guessers, we can then use the updated publish game event activity to
-	// send round ended message payloads to each player including the artist in one batch.
-
-	roundResult := gameevents.RoundEndedPayload{
+	roundResults := gameevents.RoundEndedPayload{
 		Round:           state.CurrentRound,
 		ArtistID:        state.CurrentArtist,
 		Word:            state.CurrentWord.Text,
 		DrawingDuration: state.DrawingDuration,
-		Results:         results,
+		Results:         broadcastedResults,
 		TotalPot:        state.GamePot,
 		IsFinalRound:    isFinalRound,
 	}
-	_, err = sendGameEvent(ctx, state, notifyCh, gameevents.TypeRoundEnded, roundResult,
+	_, err = sendGameEvent(ctx, state, notifyCh, gameevents.TypeRoundEnded, roundResults,
 		WithMarker(eventbus.MarkerRoundEnded),
 	)
 	if err != nil {
@@ -382,4 +386,21 @@ func updatePlayerStates(state *GameState, roundResults []*gameevents.PlayerRound
 	}
 
 	return nil
+}
+
+func topRoundResults(
+	correctGuessers []*gameevents.PlayerRoundResult,
+	artist *gameevents.PlayerRoundResult,
+	n int,
+) []*gameevents.PlayerRoundResult {
+	if len(correctGuessers) < n {
+		n = len(correctGuessers)
+	}
+
+	top := correctGuessers[:n:n]
+	if artist == nil {
+		return top
+	}
+
+	return append(top, artist)
 }

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_round.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_round.go
@@ -103,16 +103,16 @@ func endRound(ctx workflow.Context, state *GameState, notifyCh workflow.Channel)
 		TotalPot:        state.GamePot,
 		IsFinalRound:    isFinalRound,
 	}
-	_, err = sendGameEvent(ctx, state, notifyCh, gameevents.TypeRoundEnded, roundResult, &sendGameEventOpts{
-		Marker: eventbus.MarkerRoundEnded,
-	})
+	_, err = sendGameEvent(ctx, state, notifyCh, gameevents.TypeRoundEnded, roundResult,
+		WithMarker(eventbus.MarkerRoundEnded),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to send round ended event to game events stream: %w", err)
 	}
-	_, err = sendGameEvent[any](ctx, state, notifyCh, gameevents.TypeRoundEnded, nil, &sendGameEventOpts{
-		StreamType: eventbus.DrawingUpdatesStreamType,
-		Marker:     eventbus.MarkerRoundEnded,
-	})
+	_, err = sendGameEvent[any](ctx, state, notifyCh, gameevents.TypeRoundEnded, nil,
+		WithStreamType(eventbus.DrawingUpdatesStreamType),
+		WithMarker(eventbus.MarkerRoundEnded),
+	)
 	if err != nil {
 		return fmt.Errorf("failed to send round ended event to drawing updates stream: %w", err)
 	}

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_round_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_round_test.go
@@ -70,43 +70,45 @@ func (s *EndRoundTestSuite) TestEndRound() {
 	sentEventOnGameEventsStream := false
 	sentEventOnDrawingUpdatesStream := false
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeRoundEnded && params.StreamType == eventbus.GameEventsStreamType {
-				sentEventOnGameEventsStream = true
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeRoundEnded && params.StreamType == eventbus.GameEventsStreamType {
+					sentEventOnGameEventsStream = true
 
-				var payload gameevents.RoundEndedPayload
-				raw := params.EventPayload.(map[string]interface{})
-				b, err := json.Marshal(raw)
-				s.Require().NoError(err)
-				s.Require().NoError(json.Unmarshal(b, &payload))
+					var payload gameevents.RoundEndedPayload
+					raw := event.EventPayload.(map[string]interface{})
+					b, err := json.Marshal(raw)
+					s.Require().NoError(err)
+					s.Require().NoError(json.Unmarshal(b, &payload))
 
-				s.Equal(uint8(DefaultRoundNumber), payload.Round)
-				s.NotEmpty(payload.ArtistID)
-				s.NotEmpty(payload.Word)
-				s.NotEmpty(payload.DrawingDuration)
-				s.NotEmpty(payload.Results)
-				s.NotEmpty(payload.TotalPot)
-				s.False(payload.IsFinalRound)
+					s.Equal(uint8(DefaultRoundNumber), payload.Round)
+					s.NotEmpty(payload.ArtistID)
+					s.NotEmpty(payload.Word)
+					s.NotEmpty(payload.DrawingDuration)
+					s.NotEmpty(payload.Results)
+					s.NotEmpty(payload.TotalPot)
+					s.False(payload.IsFinalRound)
+				}
+
+				if params.EventType == gameevents.TypeRoundEnded && params.StreamType == eventbus.DrawingUpdatesStreamType {
+					sentEventOnDrawingUpdatesStream = true
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
+				})
 			}
-
-			if params.EventType == gameevents.TypeRoundEnded && params.StreamType == eventbus.DrawingUpdatesStreamType {
-				sentEventOnDrawingUpdatesStream = true
-			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeRoundEnded {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -121,9 +123,7 @@ func (s *EndRoundTestSuite) TestEndRound() {
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_round_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_round_test.go
@@ -36,7 +36,7 @@ func (s *EndRoundTestSuite) TestEndRound() {
 
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -44,8 +44,6 @@ func (s *EndRoundTestSuite) TestEndRound() {
 	gameID := uuid.New()
 	player1 := uuid.New()
 	player2 := uuid.New()
-
-	var capturedState *types.GameStateView
 
 	input := types.GameInput{
 		GameID:          gameID,
@@ -124,22 +122,15 @@ func (s *EndRoundTestSuite) TestEndRound() {
 					})
 				}
 			}
-		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
+
 			if params.EventType == gameevents.TypeRoundEnded {
-				val, err := s.env.QueryWorkflow(QueryGetGameState)
-				s.NoError(err)
-
-				var state types.GameStateView
-				s.NoError(val.Get(&state))
-				capturedState = &state
-
 				s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
 					GameID: gameID,
 					Reason: "test",
 				})
 			}
-
+		}).
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			return &activities.PublishGameEventsResult{}, nil
 		})
 
@@ -148,14 +139,15 @@ func (s *EndRoundTestSuite) TestEndRound() {
 	})
 	s.env.ExecuteWorkflow(GameWorkflow, input)
 
+	val, err := s.env.QueryWorkflow(QueryGetGameState)
+	s.NoError(err)
+	var capturedState types.GameStateView
+	s.NoError(val.Get(&capturedState))
+
 	s.True(sentEventOnGameEventsStream)
 	s.True(sentEventOnDrawingUpdatesStream)
 	s.Equal(2, numPlayerRoundResultsSent)
 	s.Equal(gameID, capturedState.GameID)
-	s.Equal(types.PhaseEndRound, capturedState.Phase)
-	s.Equal(types.SubPhaseNone, capturedState.SubPhase)
-	s.NotEmpty(capturedState.CurrentArtist)
-	s.NotEmpty(capturedState.CurrentWord)
 	s.Len(capturedState.Players, 2)
 }
 

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_round_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_end_round_test.go
@@ -67,6 +67,7 @@ func (s *EndRoundTestSuite) TestEndRound() {
 		})
 	}, 200*time.Millisecond)
 
+	numPlayerRoundResultsSent := 0
 	sentEventOnGameEventsStream := false
 	sentEventOnDrawingUpdatesStream := false
 
@@ -74,38 +75,54 @@ func (s *EndRoundTestSuite) TestEndRound() {
 		Run(func(args mock.Arguments) {
 			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			for _, event := range params.Events {
-				if params.EventType == gameevents.TypeRoundEnded && params.StreamType == eventbus.GameEventsStreamType {
-					sentEventOnGameEventsStream = true
-
-					var payload gameevents.RoundEndedPayload
+			switch params.EventType {
+			case gameevents.TypePlayerRoundResult:
+				for _, event := range params.Events {
+					var payload gameevents.PlayerRoundResult
 					raw := event.EventPayload.(map[string]interface{})
 					b, err := json.Marshal(raw)
 					s.Require().NoError(err)
 					s.Require().NoError(json.Unmarshal(b, &payload))
-
-					s.Equal(uint8(DefaultRoundNumber), payload.Round)
-					s.NotEmpty(payload.ArtistID)
-					s.NotEmpty(payload.Word)
-					s.NotEmpty(payload.DrawingDuration)
-					s.NotEmpty(payload.Results)
-					s.NotEmpty(payload.TotalPot)
-					s.False(payload.IsFinalRound)
+					numPlayerRoundResultsSent++
 				}
 
-				if params.EventType == gameevents.TypeRoundEnded && params.StreamType == eventbus.DrawingUpdatesStreamType {
-					sentEventOnDrawingUpdatesStream = true
+			case gameevents.TypeRoundEnded:
+				for _, event := range params.Events {
+					if params.EventType == gameevents.TypeRoundEnded && params.StreamType == eventbus.GameEventsStreamType {
+						sentEventOnGameEventsStream = true
+
+						var payload gameevents.RoundEndedPayload
+						raw := event.EventPayload.(map[string]interface{})
+						b, err := json.Marshal(raw)
+						s.Require().NoError(err)
+						s.Require().NoError(json.Unmarshal(b, &payload))
+
+						s.Equal(uint8(DefaultRoundNumber), payload.Round)
+						s.NotEmpty(payload.ArtistID)
+						s.NotEmpty(payload.Word)
+						s.NotEmpty(payload.DrawingDuration)
+						s.NotEmpty(payload.Results)
+						s.NotEmpty(payload.TotalPot)
+						s.False(payload.IsFinalRound)
+					}
+
+					if params.EventType == gameevents.TypeRoundEnded && params.StreamType == eventbus.DrawingUpdatesStreamType {
+						sentEventOnDrawingUpdatesStream = true
+					}
 				}
 
-				if event.TargetClientID == uuid.Nil {
-					return
-				}
+			default:
+				for _, event := range params.Events {
+					if event.TargetClientID == uuid.Nil {
+						continue
+					}
 
-				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-					CorrelationID: event.CorrelationID,
-					InstanceID:    instanceID,
-					Status:        gameevents.AckStatusDelivered,
-				})
+					s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+						CorrelationID: event.CorrelationID,
+						InstanceID:    instanceID,
+						Status:        gameevents.AckStatusDelivered,
+					})
+				}
 			}
 		}).
 		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
@@ -133,6 +150,7 @@ func (s *EndRoundTestSuite) TestEndRound() {
 
 	s.True(sentEventOnGameEventsStream)
 	s.True(sentEventOnDrawingUpdatesStream)
+	s.Equal(2, numPlayerRoundResultsSent)
 	s.Equal(gameID, capturedState.GameID)
 	s.Equal(types.PhaseEndRound, capturedState.Phase)
 	s.Equal(types.SubPhaseNone, capturedState.SubPhase)

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_in_round.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_in_round.go
@@ -75,7 +75,7 @@ func handleSubPhaseConfirmArtist(
 		ArtistID:     state.CurrentArtist,
 		CurrentRound: state.CurrentRound,
 	}
-	_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypeArtistConfirmed, payload, nil)
+	_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypeArtistConfirmed, payload)
 	if err != nil {
 		return fmt.Errorf("failed to send artist confirmed event: %w", err)
 	}
@@ -99,7 +99,7 @@ func handleSubPhaseWordSelection(
 			EndsAt:       workflow.Now(ctx).UTC().Add(types.WordSelectionTimeout),
 		}
 		_, err := sendGameEvent(
-			ctx, state, notifyCh, gameevents.TypeBeginWordSelection, beginWordSelectionPayload, nil,
+			ctx, state, notifyCh, gameevents.TypeBeginWordSelection, beginWordSelectionPayload,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to send begin word selection event: %w", err)
@@ -114,7 +114,7 @@ func handleSubPhaseWordSelection(
 		CurrentRound: state.CurrentRound,
 		WordTokens:   toWordTokens(state.CurrentWord.Tokens),
 	}
-	_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypeWordSelected, wordSelectedPayload, nil)
+	_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypeWordSelected, wordSelectedPayload)
 	if err != nil {
 		return fmt.Errorf("failed to send word selected event: %w", err)
 	}
@@ -131,7 +131,7 @@ func handleSubPhaseDrawing(ctx workflow.Context, state *GameState, notifyCh work
 		CurrentRound: state.CurrentRound,
 		EndsAt:       workflow.Now(ctx).UTC().Add(state.DrawingDuration),
 	}
-	_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypeBeginDrawing, beginDrawingPayload, nil)
+	_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypeBeginDrawing, beginDrawingPayload)
 	if err != nil {
 		return fmt.Errorf("failed to send begin drawing event: %w", err)
 	}
@@ -194,7 +194,7 @@ func handleSubPhaseDrawing(ctx workflow.Context, state *GameState, notifyCh work
 		CurrentRound: state.CurrentRound,
 		Word:         state.CurrentWord.Text,
 	}
-	_, err = sendGameEvent(ctx, state, notifyCh, gameevents.TypeEndDrawing, endDrawingPayload, nil)
+	_, err = sendGameEvent(ctx, state, notifyCh, gameevents.TypeEndDrawing, endDrawingPayload)
 	if err != nil {
 		state.Logger().Error("failed to send end drawing event", "error", err)
 	}
@@ -233,7 +233,7 @@ func sendArtistDisconnectedEvent(ctx workflow.Context, state *GameState, notifyC
 		CurrentRound: state.CurrentRound,
 		ArtistID:     state.CurrentArtist,
 	}
-	_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypeArtistDisconnected, payload, nil)
+	_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypeArtistDisconnected, payload)
 	if err != nil {
 		state.Logger().Error("failed to send artist disconnected event", "error", err)
 	}
@@ -396,10 +396,9 @@ func scheduleNextArtistSelection(ctx workflow.Context, state *GameState, notifyC
 		Round:    state.CurrentRound + 1,
 	}
 	delivered, err := sendGameEvent(
-		ctx, state, notifyCh, gameevents.TypeNextArtistSelected, payload, &sendGameEventOpts{
-			TargetClientID: nextArtist,
-			WaitForAck:     true,
-		},
+		ctx, state, notifyCh, gameevents.TypeNextArtistSelected, payload,
+		WithTargetClient(nextArtist),
+		WithAck(),
 	)
 	if err != nil {
 		state.Logger().Error("failed to send next artist selected event", "error", err)
@@ -499,7 +498,7 @@ func scheduleHints(ctx workflow.Context, state *GameState, notifyCh workflow.Cha
 			CurrentRound: state.CurrentRound,
 			WordHint:     hint,
 		}
-		_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypeWordHintRevealed, payload, nil)
+		_, err := sendGameEvent(ctx, state, notifyCh, gameevents.TypeWordHintRevealed, payload)
 		if err != nil {
 			state.Logger().Error("failed to send word hint revealed event", "error", err)
 		} else {

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_in_round_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_in_round_test.go
@@ -65,34 +65,36 @@ func (s *InRoundTestSuite) TestConfirmsArtist() {
 	}, 200*time.Millisecond)
 
 	sentConfirmArtistEvent := false
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeArtistConfirmed {
-				sentConfirmArtistEvent = true
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeArtistConfirmed {
+					sentConfirmArtistEvent = true
 
-				var payload gameevents.ArtistConfirmedPayload
-				raw := params.EventPayload.(map[string]interface{})
-				b, err := json.Marshal(raw)
-				s.Require().NoError(err)
-				s.Require().NoError(json.Unmarshal(b, &payload))
+					var payload gameevents.ArtistConfirmedPayload
+					raw := event.EventPayload.(map[string]interface{})
+					b, err := json.Marshal(raw)
+					s.Require().NoError(err)
+					s.Require().NoError(json.Unmarshal(b, &payload))
 
-				s.NotEmpty(payload.ArtistID)
-				s.Equal(uint8(DefaultRoundNumber), payload.CurrentRound)
+					s.NotEmpty(payload.ArtistID)
+					s.Equal(uint8(DefaultRoundNumber), payload.CurrentRound)
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
+				})
 			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeArtistConfirmed {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -107,9 +109,7 @@ func (s *InRoundTestSuite) TestConfirmsArtist() {
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
@@ -178,25 +178,27 @@ func (s *InRoundTestSuite) TestWordSelected_AfterTimeout() {
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeBeginWordSelection {
-				sentBeginWordSelectionEvent = true
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeBeginWordSelection {
+					sentBeginWordSelectionEvent = true
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
+				})
 			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeWordSelected {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -211,9 +213,7 @@ func (s *InRoundTestSuite) TestWordSelected_AfterTimeout() {
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
@@ -285,31 +285,33 @@ func (s *InRoundTestSuite) TestWordSelected_ArtistProvided() {
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeBeginWordSelection {
-				sentBeginWordSelectionEvent = true
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeBeginWordSelection {
+					sentBeginWordSelectionEvent = true
 
-				s.env.SignalWorkflow(SignalWordSelected, WordSelectedSignal{
-					GameID:       gameID,
-					CurrentRound: 1,
-					Word:         selectedWord,
+					s.env.SignalWorkflow(SignalWordSelected, WordSelectedSignal{
+						GameID:       gameID,
+						CurrentRound: 1,
+						Word:         selectedWord,
+					})
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
 				})
 			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeWordSelected {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -324,9 +326,7 @@ func (s *InRoundTestSuite) TestWordSelected_ArtistProvided() {
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
@@ -386,25 +386,27 @@ func (s *InRoundTestSuite) TestBeginDrawingEventSent() {
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeBeginDrawing {
-				sentBeginDrawingEvent = true
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeBeginDrawing {
+					sentBeginDrawingEvent = true
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
+				})
 			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeBeginDrawing {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -419,9 +421,7 @@ func (s *InRoundTestSuite) TestBeginDrawingEventSent() {
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
@@ -479,25 +479,27 @@ func (s *InRoundTestSuite) TestEndDrawingEventSent() {
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeEndDrawing {
-				sentEndDrawingEvent = true
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeEndDrawing {
+					sentEndDrawingEvent = true
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
+				})
 			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeEndDrawing {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -512,9 +514,7 @@ func (s *InRoundTestSuite) TestEndDrawingEventSent() {
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
@@ -571,38 +571,40 @@ func (s *InRoundTestSuite) TestHandlesCorrectGuesses() {
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeBeginDrawing {
-				s.env.SignalWorkflow(SignalCorrectGuesses, CorrectGuessesSignal{
-					GameID:       gameID,
-					CurrentRound: DefaultRoundNumber,
-					Guesses: []types.CorrectGuess{
-						{
-							PlayerID:  player1,
-							Timestamp: time.Now().UTC(),
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeBeginDrawing {
+					s.env.SignalWorkflow(SignalCorrectGuesses, CorrectGuessesSignal{
+						GameID:       gameID,
+						CurrentRound: DefaultRoundNumber,
+						Guesses: []types.CorrectGuess{
+							{
+								PlayerID:  player1,
+								Timestamp: time.Now().UTC(),
+							},
+							{
+								PlayerID:  player2,
+								Timestamp: time.Now().UTC(),
+							},
 						},
-						{
-							PlayerID:  player2,
-							Timestamp: time.Now().UTC(),
-						},
-					},
+					})
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
 				})
 			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeEndDrawing {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -617,9 +619,7 @@ func (s *InRoundTestSuite) TestHandlesCorrectGuesses() {
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
@@ -677,34 +677,36 @@ func (s *InRoundTestSuite) TestSelectsNextArtist() {
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeNextArtistSelected {
-				sentNextArtistSelectedEvent = true
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeNextArtistSelected {
+					sentNextArtistSelectedEvent = true
 
-				var payload gameevents.NextArtistSelectedPayload
-				raw := params.EventPayload.(map[string]interface{})
-				b, err := json.Marshal(raw)
-				s.Require().NoError(err)
-				s.Require().NoError(json.Unmarshal(b, &payload))
+					var payload gameevents.NextArtistSelectedPayload
+					raw := event.EventPayload.(map[string]interface{})
+					b, err := json.Marshal(raw)
+					s.Require().NoError(err)
+					s.Require().NoError(json.Unmarshal(b, &payload))
 
-				s.Equal(uint8(DefaultRoundNumber+1), payload.Round)
-				s.Contains([]uuid.UUID{player1, player2}, payload.PlayerID)
+					s.Equal(uint8(DefaultRoundNumber+1), payload.Round)
+					s.Contains([]uuid.UUID{player1, player2}, payload.PlayerID)
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
+				})
 			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeEndDrawing {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -719,9 +721,7 @@ func (s *InRoundTestSuite) TestSelectsNextArtist() {
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
@@ -779,37 +779,39 @@ func (s *InRoundTestSuite) TestSendsWordHints() {
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeWordHintRevealed {
-				sentWordHintEvent = true
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeWordHintRevealed {
+					sentWordHintEvent = true
 
-				var payload gameevents.WordHintRevealedPayload
-				raw := params.EventPayload.(map[string]interface{})
-				b, err := json.Marshal(raw)
-				s.Require().NoError(err)
-				s.Require().NoError(json.Unmarshal(b, &payload))
+					var payload gameevents.WordHintRevealedPayload
+					raw := event.EventPayload.(map[string]interface{})
+					b, err := json.Marshal(raw)
+					s.Require().NoError(err)
+					s.Require().NoError(json.Unmarshal(b, &payload))
 
-				s.Equal(uint8(DefaultRoundNumber), payload.CurrentRound)
-				s.NotEmpty(payload.WordHint)
-				s.GreaterOrEqual(payload.WordHint.WordTokenIdx, 0)
-				s.GreaterOrEqual(payload.WordHint.CharIdx, 0)
-				s.NotZero(payload.WordHint.Char)
+					s.Equal(uint8(DefaultRoundNumber), payload.CurrentRound)
+					s.NotEmpty(payload.WordHint)
+					s.GreaterOrEqual(payload.WordHint.WordTokenIdx, 0)
+					s.GreaterOrEqual(payload.WordHint.CharIdx, 0)
+					s.NotZero(payload.WordHint.Char)
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
+				})
 			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeEndDrawing {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -824,9 +826,7 @@ func (s *InRoundTestSuite) TestSendsWordHints() {
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
@@ -885,52 +885,54 @@ func (s *InRoundTestSuite) TestHandlesArtistDisconnect_ArtistDisconnectSignalSen
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeArtistConfirmed {
-				var payload gameevents.ArtistConfirmedPayload
-				raw := params.EventPayload.(map[string]interface{})
-				b, err := json.Marshal(raw)
-				s.Require().NoError(err)
-				s.Require().NoError(json.Unmarshal(b, &payload))
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeArtistConfirmed {
+					var payload gameevents.ArtistConfirmedPayload
+					raw := event.EventPayload.(map[string]interface{})
+					b, err := json.Marshal(raw)
+					s.Require().NoError(err)
+					s.Require().NoError(json.Unmarshal(b, &payload))
 
-				artistID = payload.ArtistID
-			}
+					artistID = payload.ArtistID
+				}
 
-			if params.EventType == gameevents.TypeBeginDrawing {
-				s.env.SignalWorkflow(SignalArtistDisconnected, ArtistDisconnectedSignal{
-					GameID:       gameID,
-					CurrentRound: DefaultRoundNumber,
-					ArtistID:     artistID,
+				if params.EventType == gameevents.TypeBeginDrawing {
+					s.env.SignalWorkflow(SignalArtistDisconnected, ArtistDisconnectedSignal{
+						GameID:       gameID,
+						CurrentRound: DefaultRoundNumber,
+						ArtistID:     artistID,
+					})
+				}
+
+				if params.EventType == gameevents.TypeArtistDisconnected {
+					sentArtistDisconnectedEvent = true
+
+					var payload gameevents.ArtistDisconnectedPayload
+					raw := event.EventPayload.(map[string]interface{})
+					b, err := json.Marshal(raw)
+					s.Require().NoError(err)
+					s.Require().NoError(json.Unmarshal(b, &payload))
+
+					s.Equal(artistID, payload.ArtistID)
+					s.Equal(uint8(DefaultRoundNumber), payload.CurrentRound)
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
 				})
 			}
-
-			if params.EventType == gameevents.TypeArtistDisconnected {
-				sentArtistDisconnectedEvent = true
-
-				var payload gameevents.ArtistDisconnectedPayload
-				raw := params.EventPayload.(map[string]interface{})
-				b, err := json.Marshal(raw)
-				s.Require().NoError(err)
-				s.Require().NoError(json.Unmarshal(b, &payload))
-
-				s.Equal(artistID, payload.ArtistID)
-				s.Equal(uint8(DefaultRoundNumber), payload.CurrentRound)
-			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeEndDrawing {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -945,9 +947,7 @@ func (s *InRoundTestSuite) TestHandlesArtistDisconnect_ArtistDisconnectSignalSen
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
@@ -1006,50 +1006,52 @@ func (s *InRoundTestSuite) TestHandlesArtistDisconnect_ArtistLeft() {
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.EventType == gameevents.TypeArtistConfirmed {
-				var payload gameevents.ArtistConfirmedPayload
-				raw := params.EventPayload.(map[string]interface{})
-				b, err := json.Marshal(raw)
-				s.Require().NoError(err)
-				s.Require().NoError(json.Unmarshal(b, &payload))
+			for _, event := range params.Events {
+				if params.EventType == gameevents.TypeArtistConfirmed {
+					var payload gameevents.ArtistConfirmedPayload
+					raw := event.EventPayload.(map[string]interface{})
+					b, err := json.Marshal(raw)
+					s.Require().NoError(err)
+					s.Require().NoError(json.Unmarshal(b, &payload))
 
-				artistID = payload.ArtistID
-			}
+					artistID = payload.ArtistID
+				}
 
-			if params.EventType == gameevents.TypeBeginDrawing {
-				s.env.SignalWorkflow(SignalPlayersLeave, PlayersLeaveSignal{
-					PlayerIDs: []uuid.UUID{artistID},
+				if params.EventType == gameevents.TypeBeginDrawing {
+					s.env.SignalWorkflow(SignalPlayersLeave, PlayersLeaveSignal{
+						PlayerIDs: []uuid.UUID{artistID},
+					})
+				}
+
+				if params.EventType == gameevents.TypeArtistDisconnected {
+					sentArtistDisconnectedEvent = true
+
+					var payload gameevents.ArtistDisconnectedPayload
+					raw := event.EventPayload.(map[string]interface{})
+					b, err := json.Marshal(raw)
+					s.Require().NoError(err)
+					s.Require().NoError(json.Unmarshal(b, &payload))
+
+					s.Equal(artistID, payload.ArtistID)
+					s.Equal(uint8(DefaultRoundNumber), payload.CurrentRound)
+				}
+
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
 				})
 			}
-
-			if params.EventType == gameevents.TypeArtistDisconnected {
-				sentArtistDisconnectedEvent = true
-
-				var payload gameevents.ArtistDisconnectedPayload
-				raw := params.EventPayload.(map[string]interface{})
-				b, err := json.Marshal(raw)
-				s.Require().NoError(err)
-				s.Require().NoError(json.Unmarshal(b, &payload))
-
-				s.Equal(artistID, payload.ArtistID)
-				s.Equal(uint8(DefaultRoundNumber), payload.CurrentRound)
-			}
-
-			if params.TargetClientID == uuid.Nil {
-				return
-			}
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
 		}).
-		Return(func(ctx context.Context, params activities.PublishGameEventParams) (*activities.PublishGameEventResult, error) {
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
 			if params.EventType == gameevents.TypeEndDrawing {
 				val, err := s.env.QueryWorkflow(QueryGetGameState)
 				s.NoError(err)
@@ -1064,9 +1066,7 @@ func (s *InRoundTestSuite) TestHandlesArtistDisconnect_ArtistLeft() {
 				})
 			}
 
-			return &activities.PublishGameEventResult{
-				MessageID: "some-message-id",
-			}, nil
+			return &activities.PublishGameEventsResult{}, nil
 		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_in_round_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_in_round_test.go
@@ -33,7 +33,7 @@ func (s *InRoundTestSuite) TestConfirmsArtist() {
 
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -81,6 +81,18 @@ func (s *InRoundTestSuite) TestConfirmsArtist() {
 
 					s.NotEmpty(payload.ArtistID)
 					s.Equal(uint8(DefaultRoundNumber), payload.CurrentRound)
+
+					val, err := s.env.QueryWorkflow(QueryGetGameState)
+					s.NoError(err)
+
+					var state types.GameStateView
+					s.NoError(val.Get(&state))
+					capturedState = &state
+
+					s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
+						GameID: gameID,
+						Reason: "test",
+					})
 				}
 
 				if event.TargetClientID == uuid.Nil {
@@ -95,20 +107,6 @@ func (s *InRoundTestSuite) TestConfirmsArtist() {
 			}
 		}).
 		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
-			if params.EventType == gameevents.TypeArtistConfirmed {
-				val, err := s.env.QueryWorkflow(QueryGetGameState)
-				s.NoError(err)
-
-				var state types.GameStateView
-				s.NoError(val.Get(&state))
-				capturedState = &state
-
-				s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
-					GameID: gameID,
-					Reason: "test",
-				})
-			}
-
 			return &activities.PublishGameEventsResult{}, nil
 		})
 
@@ -128,7 +126,7 @@ func (s *InRoundTestSuite) TestConfirmsArtist() {
 func (s *InRoundTestSuite) TestWordSelected_AfterTimeout() {
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -241,7 +239,7 @@ func (s *InRoundTestSuite) TestWordSelected_ArtistProvided() {
 
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -354,7 +352,7 @@ func (s *InRoundTestSuite) TestBeginDrawingEventSent() {
 
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -447,7 +445,7 @@ func (s *InRoundTestSuite) TestEndDrawingEventSent() {
 
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -540,7 +538,7 @@ func (s *InRoundTestSuite) TestHandlesCorrectGuesses() {
 
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -645,7 +643,7 @@ func (s *InRoundTestSuite) TestSelectsNextArtist() {
 
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -747,7 +745,7 @@ func (s *InRoundTestSuite) TestSendsWordHints() {
 
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -852,7 +850,7 @@ func (s *InRoundTestSuite) TestHandlesArtistDisconnect_ArtistDisconnectSignalSen
 
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -973,7 +971,7 @@ func (s *InRoundTestSuite) TestHandlesArtistDisconnect_ArtistLeft() {
 
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_prepare_round.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_prepare_round.go
@@ -82,10 +82,9 @@ func selectAndNotifyArtist(
 			CurrentRound: state.CurrentRound,
 		}
 		delivered, err := sendGameEvent(
-			ctx, state, notifyCh, gameevents.TypeArtistSelected, payload, &sendGameEventOpts{
-				TargetClientID: artistID,
-				WaitForAck:     true,
-			},
+			ctx, state, notifyCh, gameevents.TypeArtistSelected, payload,
+			WithTargetClient(artistID),
+			WithAck(),
 		)
 		if err != nil {
 			return uuid.Nil, fmt.Errorf("failed to send artist selected event: %w", err)

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_prepare_round_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_prepare_round_test.go
@@ -25,7 +25,7 @@ func TestPhasePrepareRound(t *testing.T) {
 func (s *PhasePrepareRoundTestSuite) TestPreparesRoundSuccessfully() {
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -54,8 +54,6 @@ func (s *PhasePrepareRoundTestSuite) TestPreparesRoundSuccessfully() {
 		})
 	}, 200*time.Millisecond)
 
-	var capturedState *types.GameStateView
-
 	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			params := args.Get(1).(activities.PublishGameEventsParams)
@@ -77,13 +75,6 @@ func (s *PhasePrepareRoundTestSuite) TestPreparesRoundSuccessfully() {
 			}
 		}).
 		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
-			val, err := s.env.QueryWorkflow(QueryGetGameState)
-			s.NoError(err)
-
-			var state types.GameStateView
-			s.NoError(val.Get(&state))
-			capturedState = &state
-
 			s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
 				GameID: gameID,
 				Reason: "test",
@@ -97,6 +88,14 @@ func (s *PhasePrepareRoundTestSuite) TestPreparesRoundSuccessfully() {
 	})
 	s.env.ExecuteWorkflow(GameWorkflow, input)
 
+	val, err := s.env.QueryWorkflow(QueryGetGameState)
+	s.NoError(err)
+	var capturedState types.GameStateView
+	s.NoError(val.Get(&capturedState))
+
+	s.Equal(gameID, capturedState.GameID)
+	s.Len(capturedState.Players, 2)
+
 	s.Equal(gameID, capturedState.GameID)
 	s.Len(capturedState.Players, 2)
 }
@@ -104,7 +103,7 @@ func (s *PhasePrepareRoundTestSuite) TestPreparesRoundSuccessfully() {
 func (s *PhasePrepareRoundTestSuite) TestCouldNotSelectAndNotifyArtist() {
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -167,7 +166,7 @@ func (s *PhasePrepareRoundTestSuite) TestCouldNotSelectAndNotifyArtist() {
 func (s *PhasePrepareRoundTestSuite) TestNotEnoughPlayersAfterSelectingArtist() {
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	instanceID := uuid.New()
@@ -196,8 +195,6 @@ func (s *PhasePrepareRoundTestSuite) TestNotEnoughPlayersAfterSelectingArtist() 
 		})
 	}, 200*time.Millisecond)
 
-	var capturedState *types.GameStateView
-
 	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			params := args.Get(1).(activities.PublishGameEventsParams)
@@ -223,13 +220,6 @@ func (s *PhasePrepareRoundTestSuite) TestNotEnoughPlayersAfterSelectingArtist() 
 			}
 		}).
 		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
-			val, err := s.env.QueryWorkflow(QueryGetGameState)
-			s.NoError(err)
-
-			var state types.GameStateView
-			s.NoError(val.Get(&state))
-			capturedState = &state
-
 			s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
 				GameID: gameID,
 				Reason: "test",
@@ -242,6 +232,11 @@ func (s *PhasePrepareRoundTestSuite) TestNotEnoughPlayersAfterSelectingArtist() 
 		ID: serverID.String(),
 	})
 	s.env.ExecuteWorkflow(GameWorkflow, input)
+
+	val, err := s.env.QueryWorkflow(QueryGetGameState)
+	s.NoError(err)
+	var capturedState types.GameStateView
+	s.NoError(val.Get(&capturedState))
 
 	s.Equal(gameID, capturedState.GameID)
 	s.Empty(capturedState.CurrentArtist)

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_prepare_round_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_prepare_round_test.go
@@ -53,30 +53,30 @@ func (s *PhasePrepareRoundTestSuite) TestPreparesRoundSuccessfully() {
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.TargetClientID == uuid.Nil {
-				return
+			for _, event := range params.Events {
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.Equal(gameevents.TypeArtistSelected, params.EventType)
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
+				})
+
+				s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
+					GameID: gameID,
+					Reason: "test",
+				})
 			}
-
-			s.Equal(gameevents.TypeArtistSelected, params.EventType)
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
-
-			s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
-				GameID: gameID,
-				Reason: "test",
-			})
 		}).
-		Return(&activities.PublishGameEventResult{
-			MessageID: "some-message-id",
-		}, nil)
+		Return(&activities.PublishGameEventsResult{}, nil)
 
 	var capturedState *types.GameStateView
 	s.env.RegisterDelayedCallback(func() {
@@ -131,10 +131,8 @@ func (s *PhasePrepareRoundTestSuite) TestCouldNotSelectAndNotifyArtist() {
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
-		Return(&activities.PublishGameEventResult{
-			MessageID: "some-message-id",
-		}, nil)
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
+		Return(&activities.PublishGameEventsResult{}, nil)
 
 	var capturedState *types.GameStateView
 	s.env.RegisterDelayedCallback(func() {
@@ -196,34 +194,34 @@ func (s *PhasePrepareRoundTestSuite) TestNotEnoughPlayersAfterSelectingArtist() 
 		})
 	}, 200*time.Millisecond)
 
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			params := args.Get(1).(activities.PublishGameEventParams)
+			params := args.Get(1).(activities.PublishGameEventsParams)
 
-			if params.TargetClientID == uuid.Nil {
-				return
+			for _, event := range params.Events {
+				if event.TargetClientID == uuid.Nil {
+					return
+				}
+
+				s.Equal(gameevents.TypeArtistSelected, params.EventType)
+
+				s.env.SignalWorkflow(SignalPlayersLeave, PlayersLeaveSignal{
+					PlayerIDs: []uuid.UUID{player1},
+				})
+
+				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
+					CorrelationID: event.CorrelationID,
+					InstanceID:    instanceID,
+					Status:        gameevents.AckStatusDelivered,
+				})
+
+				s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
+					GameID: gameID,
+					Reason: "test",
+				})
 			}
-
-			s.Equal(gameevents.TypeArtistSelected, params.EventType)
-
-			s.env.SignalWorkflow(SignalPlayersLeave, PlayersLeaveSignal{
-				PlayerIDs: []uuid.UUID{player1},
-			})
-
-			s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
-				CorrelationID: params.CorrelationID,
-				InstanceID:    instanceID,
-				Status:        gameevents.AckStatusDelivered,
-			})
-
-			s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
-				GameID: gameID,
-				Reason: "test",
-			})
 		}).
-		Return(&activities.PublishGameEventResult{
-			MessageID: "some-message-id",
-		}, nil)
+		Return(&activities.PublishGameEventsResult{}, nil)
 
 	var capturedState *types.GameStateView
 	s.env.RegisterDelayedCallback(func() {

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_prepare_round_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_prepare_round_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -53,40 +54,43 @@ func (s *PhasePrepareRoundTestSuite) TestPreparesRoundSuccessfully() {
 		})
 	}, 200*time.Millisecond)
 
+	var capturedState *types.GameStateView
+
 	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			params := args.Get(1).(activities.PublishGameEventsParams)
+
+			if params.EventType != gameevents.TypeArtistSelected {
+				return
+			}
 
 			for _, event := range params.Events {
 				if event.TargetClientID == uuid.Nil {
 					return
 				}
 
-				s.Equal(gameevents.TypeArtistSelected, params.EventType)
-
 				s.env.SignalWorkflow(SignalEventAck, gameevents.EventAckPayload{
 					CorrelationID: event.CorrelationID,
 					InstanceID:    instanceID,
 					Status:        gameevents.AckStatusDelivered,
 				})
-
-				s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
-					GameID: gameID,
-					Reason: "test",
-				})
 			}
 		}).
-		Return(&activities.PublishGameEventsResult{}, nil)
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
+			val, err := s.env.QueryWorkflow(QueryGetGameState)
+			s.NoError(err)
 
-	var capturedState *types.GameStateView
-	s.env.RegisterDelayedCallback(func() {
-		val, err := s.env.QueryWorkflow(QueryGetGameState)
-		s.NoError(err)
+			var state types.GameStateView
+			s.NoError(val.Get(&state))
+			capturedState = &state
 
-		var state types.GameStateView
-		s.NoError(val.Get(&state))
-		capturedState = &state
-	}, 300*time.Millisecond)
+			s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
+				GameID: gameID,
+				Reason: "test",
+			})
+
+			return &activities.PublishGameEventsResult{}, nil
+		})
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
 		ID: serverID.String(),
@@ -94,8 +98,6 @@ func (s *PhasePrepareRoundTestSuite) TestPreparesRoundSuccessfully() {
 	s.env.ExecuteWorkflow(GameWorkflow, input)
 
 	s.Equal(gameID, capturedState.GameID)
-	s.Equal(types.PhaseEndRound, capturedState.Phase)
-	s.Empty(capturedState.CurrentArtist)
 	s.Len(capturedState.Players, 2)
 }
 
@@ -194,16 +196,20 @@ func (s *PhasePrepareRoundTestSuite) TestNotEnoughPlayersAfterSelectingArtist() 
 		})
 	}, 200*time.Millisecond)
 
+	var capturedState *types.GameStateView
+
 	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			params := args.Get(1).(activities.PublishGameEventsParams)
+
+			if params.EventType != gameevents.TypeArtistSelected {
+				return
+			}
 
 			for _, event := range params.Events {
 				if event.TargetClientID == uuid.Nil {
 					return
 				}
-
-				s.Equal(gameevents.TypeArtistSelected, params.EventType)
 
 				s.env.SignalWorkflow(SignalPlayersLeave, PlayersLeaveSignal{
 					PlayerIDs: []uuid.UUID{player1},
@@ -214,31 +220,23 @@ func (s *PhasePrepareRoundTestSuite) TestNotEnoughPlayersAfterSelectingArtist() 
 					InstanceID:    instanceID,
 					Status:        gameevents.AckStatusDelivered,
 				})
-
-				s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
-					GameID: gameID,
-					Reason: "test",
-				})
 			}
 		}).
-		Return(&activities.PublishGameEventsResult{}, nil)
+		Return(func(ctx context.Context, params activities.PublishGameEventsParams) (*activities.PublishGameEventsResult, error) {
+			val, err := s.env.QueryWorkflow(QueryGetGameState)
+			s.NoError(err)
 
-	var capturedState *types.GameStateView
-	s.env.RegisterDelayedCallback(func() {
-		val, err := s.env.QueryWorkflow(QueryGetGameState)
-		s.NoError(err)
+			var state types.GameStateView
+			s.NoError(val.Get(&state))
+			capturedState = &state
 
-		var state types.GameStateView
-		s.NoError(val.Get(&state))
-		capturedState = &state
-	}, 300*time.Millisecond)
+			s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
+				GameID: gameID,
+				Reason: "test",
+			})
 
-	s.env.RegisterDelayedCallback(func() {
-		s.env.SignalWorkflow(SignalTerminateGame, TerminateGameSignal{
-			GameID: gameID,
-			Reason: "test",
+			return &activities.PublishGameEventsResult{}, nil
 		})
-	}, 350*time.Millisecond)
 
 	s.env.SetStartWorkflowOptions(client.StartWorkflowOptions{
 		ID: serverID.String(),
@@ -246,7 +244,6 @@ func (s *PhasePrepareRoundTestSuite) TestNotEnoughPlayersAfterSelectingArtist() 
 	s.env.ExecuteWorkflow(GameWorkflow, input)
 
 	s.Equal(gameID, capturedState.GameID)
-	s.Equal(types.PhaseEndRound, capturedState.Phase)
 	s.Empty(capturedState.CurrentArtist)
 	s.Len(capturedState.Players, 1)
 }

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_waiting_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_waiting_test.go
@@ -24,11 +24,9 @@ func TestPhaseWaiting(t *testing.T) {
 }
 
 func (s *PhaseWaitingTestSuite) TestTransitionsToPhasePrepareRound() {
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.PublishGameEventResult{
-			MessageID: "some-message-id",
-		}, nil)
+		Return(&activities.PublishGameEventsResult{}, nil)
 	s.env.OnActivity(s.activities.SelectRandomWord, mock.Anything, mock.Anything).
 		Maybe().
 		Return(&activities.SelectRandomWordResult{
@@ -85,11 +83,9 @@ func (s *PhaseWaitingTestSuite) TestTransitionsToPhasePrepareRound() {
 }
 
 func (s *PhaseWaitingTestSuite) TestNotEnoughPlayers_StaysInWaitingPhase() {
-	s.env.OnActivity(s.activities.PublishGameEvent, mock.Anything, mock.Anything).
+	s.env.OnActivity(s.activities.PublishGameEvents, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.PublishGameEventResult{
-			MessageID: "some-message-id",
-		}, nil)
+		Return(&activities.PublishGameEventsResult{}, nil)
 	s.env.OnActivity(s.activities.SelectRandomWord, mock.Anything, mock.Anything).
 		Maybe().
 		Return(&activities.SelectRandomWordResult{

--- a/services/gameplay/internal/gameflow/internal/workflow/handler_phase_waiting_test.go
+++ b/services/gameplay/internal/gameflow/internal/workflow/handler_phase_waiting_test.go
@@ -34,7 +34,7 @@ func (s *PhaseWaitingTestSuite) TestTransitionsToPhasePrepareRound() {
 		}, nil)
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	gameID := uuid.New()
@@ -93,7 +93,7 @@ func (s *PhaseWaitingTestSuite) TestNotEnoughPlayers_StaysInWaitingPhase() {
 		}, nil)
 	s.env.OnActivity(s.activities.ArchiveGame, mock.Anything, mock.Anything).
 		Maybe().
-		Return(&activities.ArchiveGameResult{})
+		Return(&activities.ArchiveGameResult{}, nil)
 
 	serverID := uuid.New()
 	gameID := uuid.New()

--- a/services/gameplay/internal/gameserver/handlers_bus.go
+++ b/services/gameplay/internal/gameserver/handlers_bus.go
@@ -49,8 +49,12 @@ func (gs *GameServer) handleEventBusMessage(_ context.Context, msg eventbus.Mess
 	case gameevents.TypeEndDrawing:
 		gs.broadcastBusMsg(msg)
 
+	case gameevents.TypePlayerRoundResult:
+		gs.sendBusMsgToTargetClient(msg, false, false)
 	case gameevents.TypeRoundEnded:
 		gs.handleRoundEnded(msg)
+	case gameevents.TypePlayerFinalResult:
+		gs.sendBusMsgToTargetClient(msg, false, false)
 	case gameevents.TypeGameEnded:
 		gs.handleGameEnded(msg)
 	}
@@ -109,7 +113,7 @@ func (gs *GameServer) handleArtistSelected(msg eventbus.Message) {
 		return
 	}
 
-	gs.sendBusMsgToTargetClient(msg)
+	gs.sendBusMsgToTargetClient(msg, true, true)
 }
 
 func (gs *GameServer) handleArtistConfirmed(msg eventbus.Message) {
@@ -133,7 +137,7 @@ func (gs *GameServer) handleNextArtistSelected(msg eventbus.Message) {
 		return
 	}
 
-	gs.sendBusMsgToTargetClient(msg)
+	gs.sendBusMsgToTargetClient(msg, true, true)
 }
 
 func (gs *GameServer) handleArtistDisconnected(msg eventbus.Message) {
@@ -209,13 +213,13 @@ func (gs *GameServer) broadcastBusMsg(msg eventbus.Message) {
 	}
 }
 
-func (gs *GameServer) sendBusMsgToTargetClient(msg eventbus.Message) {
+func (gs *GameServer) sendBusMsgToTargetClient(msg eventbus.Message, excludeSpectators bool, requiresAck bool) {
 	logger := gs.logger()
 
 	err := gs.SendDirectMsg(&DirectMsgPayload{
 		Recipients: []DirectMsgRecipient{{
 			UserID:            msg.TargetClientID,
-			ExcludeSpectators: true,
+			ExcludeSpectators: excludeSpectators,
 		}},
 		Msg: &OutgoingMessage{
 			WsMessage: WsMessage{
@@ -226,7 +230,7 @@ func (gs *GameServer) sendBusMsgToTargetClient(msg eventbus.Message) {
 				Payload:    msg.Payload,
 			},
 			CorrelationID:       msg.CorrelationID,
-			RequiresWorkflowAck: true,
+			RequiresWorkflowAck: requiresAck,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
### Description

Currently, the round/game ended payloads broadcast the results of all players in a given server. This is not ideal given this would be an unbounded message to all ws clients. This pr changes that by instead broadcasting the results of only the top 10 players + the artist if applicable. 

### Changelog

- round/game ended payloads only include top 10 players' results + artist results
- individual player results are sent to each player

### Checklist

- [X] This change has been unit tested.
